### PR TITLE
Add portforward to the vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "debian/jessie64"
   config.vm.provider "virtualbox"
+  config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.provision :ansible do |ansible|
    ansible.playbook = "playbook.yml"
    


### PR DESCRIPTION
The host machine will now listen on port 8080 and forward to the guest
machine on port 80.
