### PR TITLE
MySQL Ansible update twice

### DIFF
--- a/roles/mysql/tasks/databases.yml
+++ b/roles/mysql/tasks/databases.yml
@@ -4,9 +4,11 @@
   become: yes
   become_method: sudo
   mysql_db:
+    login_user: root
+    login_password: "{{mysql_root_password}}"
     name: "{{ item.name }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
-  with_items: mysql_databases
+  with_items: "{{mysql_databases}}"
   when: mysql_databases|length > 0

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -12,7 +12,7 @@
   apt:
     pkg: "{{item}}"
     update_cache: yes
-  with_items: mysql_packages
+  with_items: "{{mysql_packages}}"
 
 - name: MySQL | Ensure MySQL is running
   become: yes

--- a/roles/mysql/tasks/secure.yml
+++ b/roles/mysql/tasks/secure.yml
@@ -1,8 +1,23 @@
-# file: mysql/tasks/secure.yml
+- name: MySQL | Test whether the root password has already been changed (external hostname).
+  mysql_user:
+    user: root
+    host: "{{item}}"
+    password: "{{mysql_root_password}}"
+    login_user: root
+    login_password: "{{mysql_root_password}}"
+    priv: "*.*:ALL,GRANT"
+  with_items:
+   - "{{ansible_hostname}}"
+   - 127.0.0.1
+   - ::1
+   - localhost
+  register: root_pw_already_set
+  ignore_errors: yes
+  when: ansible_hostname != 'localhost'
+  tags:
+    - change_root_password
 
 - name: MySQL | Changing the root password (external hostname).
-  become: yes
-  become_method: sudo
   mysql_user:
     user: root
     host: "{{item}}"
@@ -15,13 +30,11 @@
    - 127.0.0.1
    - ::1
    - localhost
-  when: "ansible_hostname != 'localhost'"
+  when: "root_pw_already_set|failed and ansible_hostname != 'localhost'"
   tags:
     - change_root_password
 
 - name: MySQL | Test whether the root password has already been changed (local hostname).
-  become: yes
-  become_method: sudo
   mysql_user:
     user: root
     host: "{{item}}"
@@ -40,8 +53,6 @@
     - change_root_password
 
 - name: MySQL | Changing the root password (local hostname).
-  become: yes
-  become_method: sudo
   mysql_user:
     user: root
     host: "{{item}}"
@@ -53,34 +64,6 @@
    - 127.0.0.1
    - ::1
    - localhost
-  when: "ansible_hostname == 'localhost'"
+  when: "root_pw_already_set|failed and ansible_hostname == 'localhost'"
   tags:
     - change_root_password
-
-- name: MySQL | Configure MySql for easy access as root user
-  become: yes
-  become_method: sudo
-  template:
-    src: root_dot_my.cnf.j2
-    dest: /root/.my.cnf
-    owner: root
-    group: root
-    mode: 0600
-
-- name: MySQL | Remove anonymous MySQL server user
-  become: yes
-  become_method: sudo
-  mysql_user:
-    name: ""
-    host: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_hostname}}"
-    - localhost
-
-- name: MySQL | Remove the MySQL test database
-  become: yes
-  become_method: sudo
-  mysql_db:
-    name: test
-    state: absent

--- a/roles/mysql/tasks/users.yml
+++ b/roles/mysql/tasks/users.yml
@@ -4,10 +4,12 @@
   become: yes
   become_method: sudo
   mysql_user:
+    login_user: root
+    login_password: "{{mysql_root_password}}"
     name: "{{item.name}}"
     password: "{{item.pass | default('pass')}}"
     priv: "{{item.priv | default('*.*:ALL')}}"
     state: present
     host: "{{item.host | default('localhost')}}"
-  with_items: mysql_users
+  with_items: "{{mysql_users}}"
   when: mysql_users|length > 0


### PR DESCRIPTION
Updated MySQL playbook

MySQL is now able to run the ansible script twice

Bug fix for issue #55

Tested and confirmed working on
Ansible 2.1.0.0
Vagrant 1.8.1
Ubuntu 14.04 LTS
VirtualBox

Tested by Jesper and Christian
