### PR TITLE
Update have to become sudo in ansible roles (server, apache2) "bug fix for issue #61"

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,6 @@
 - hosts: webserver
-
+  become: yes
+  become_method: sudo
   roles: 
     - server
     - apache2

--- a/roles/apache2/tasks/main.yml
+++ b/roles/apache2/tasks/main.yml
@@ -2,9 +2,8 @@
 # tasks file for apache2
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time=3600
-  sudo: yes
+
 - name: Install required software
   apt: name={{ item }} state=present
-  sudo: yes
   with_items:
     - apache2

--- a/roles/logserver/tasks/main.yml
+++ b/roles/logserver/tasks/main.yml
@@ -3,11 +3,9 @@
 ---
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time=3600
-  sudo: yes
 
 - name: Install required software
   apt: name={{ item }} state=present
-  sudo: yes
   with_items:
     - mysql-server
     - php5-mysql

--- a/roles/moniserv/tasks/main.yml
+++ b/roles/moniserv/tasks/main.yml
@@ -3,11 +3,9 @@
 ---
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time=3600
-  sudo: yes
 
 - name: Install required software
   apt: name={{ item }} state=present
-  sudo: yes
   with_items:
     - mysql-server
     - php5-mysql

--- a/roles/mysql/tasks/configure.yml
+++ b/roles/mysql/tasks/configure.yml
@@ -1,8 +1,6 @@
 # file: mysql/tasks/configure.yml
 
 - name: MySQL | Update the my.cnf
-  become: yes
-  become_method: sudo
   template:
     src: etc_mysql_my.cnf.j2
     dest: /etc/mysql/my.cnf

--- a/roles/mysql/tasks/databases.yml
+++ b/roles/mysql/tasks/databases.yml
@@ -1,8 +1,6 @@
 # file: mysql/tasks/databases.yml
 
 - name: MySQL | Make sure the MySQL databases are present
-  become: yes
-  become_method: sudo
   mysql_db:
     login_user: root
     login_password: "{{mysql_root_password}}"

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -1,22 +1,16 @@
 # file: mysql/tasks/install.yml
 
 - name: MySQL | Add APT repository
-  become: yes
-  become_method: sudo
   apt_repository: repo={{mysql_ppa}} update_cache=yes
   when: mysql_ppa != False and mysql_ppa != ""
 
 - name: MySQL | Make sure the MySQL packages are installed
-  become: yes
-  become_method: sudo
   apt:
     pkg: "{{item}}"
     update_cache: yes
   with_items: "{{mysql_packages}}"
 
 - name: MySQL | Ensure MySQL is running
-  become: yes
-  become_method: sudo
   service:
     name: mysql
     state: started

--- a/roles/mysql/tasks/users.yml
+++ b/roles/mysql/tasks/users.yml
@@ -1,8 +1,6 @@
 # file: mysql/tasks/users.yml
 
 - name: MySQL | Make sure the MySQL users are present
-  become: yes
-  become_method: sudo
   mysql_user:
     login_user: root
     login_password: "{{mysql_root_password}}"

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,6 +1,5 @@
 - name: Install php extensions
   apt: name={{ item }} state=present
-  sudo: yes
   with_items:
     - php5-gd 
     - libssh2-php

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -3,11 +3,9 @@
 ---
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time=3600
-  sudo: yes
 
 - name: Install required software
   apt: name={{ item }} state=present
-  sudo: yes
   with_items:
     - mysql-server
     - php5-mysql

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -1,20 +1,14 @@
 ---
 - name: Download WordPress  
-  become: yes
-  become_method: sudo
   get_url: 
     url=https://wordpress.org/latest.tar.gz 
     dest=/tmp/wordpress.tar.gz
     validate_certs=no
 
 - name: Extract WordPress  
-  become: yes
-  become_method: sudo
   unarchive: src=/tmp/wordpress.tar.gz dest=/var/www copy=no
 
 - name: Update default Apache site
-  become: yes
-  become_method: sudo
   lineinfile: 
     dest=/etc/apache2/sites-enabled/000-default.conf 
     regexp="(.)+DocumentRoot /var/www/html"
@@ -23,13 +17,9 @@
     - restart apache
 
 - name: Copy sample config file
-  become: yes
-  become_method: sudo
   command: mv /var/www/wordpress/wp-config-sample.php /var/www/wordpress/wp-config.php creates=/var/www/wordpress/wp-config.php
 
 - name: Update WordPress config file
-  become: yes
-  become_method: sudo
   lineinfile:
     dest=/var/www/wordpress/wp-config.php
     regexp="{{ item.regexp }}"


### PR DESCRIPTION
Updated MySQL playbook

All “become_method: sudo” and “sudo: yes” has been removed and add in
the playbook

Bug fix for issue #61

Tested and confirmed working on
Ansible 2.1.0.0
Vagrant 1.8.1
Ubuntu 14.04 LTS
VirtualBox

Tested by Jesper and Christian
