### PR TITLE
MySQL Ansible update twice

### DIFF
--- a/roles/mysql/tasks/secure.yml
+++ b/roles/mysql/tasks/secure.yml
@@ -12,7 +12,7 @@
    - ::1
    - localhost
   register: root_pw_already_set
-  ignore_errors: yes
+  failed_when: false
   when: ansible_hostname != 'localhost'
   tags:
     - change_root_password
@@ -30,7 +30,7 @@
    - 127.0.0.1
    - ::1
    - localhost
-  when: "root_pw_already_set|failed and ansible_hostname != 'localhost'"
+  when: "ansible_hostname != 'localhost'"
   tags:
     - change_root_password
 


### PR DESCRIPTION
Updated MySQL playbook

MySQL is now able to run the ansible script twice

Bug fix for issue #55

Tested and confirmed working on
Ansible 2.1.0.0
Vagrant 1.8.1
Ubuntu 14.04 LTS
VirtualBox

Tested by Jesper and Christian
